### PR TITLE
Fix intermittent failures when creating a null sink link.

### DIFF
--- a/files/wavexlrfix.lua
+++ b/files/wavexlrfix.lua
@@ -178,6 +178,7 @@ function createNullSink()
         else
             log:notice("Created null sink for WaveXLR source. object.id: " ..
                 n.properties["object.id"])
+            onNullSinkCreated();
         end
     end)
 
@@ -198,13 +199,17 @@ function onWaveXlrSourceRemoved()
     end
 end
 
-nullSinkForWaveXlrSource = createNullSink();
+function onNullSinkCreated()
+    log:notice("Activate event listeners");
 
+    linkOm:activate()
+    linkOm:connect("object-added", onLinkCreated)
+    waveXlrSourceOm:connect("object-added", onWaveXlrSourceAdded)
+    waveXlrSourceOm:connect("object-removed", onWaveXlrSourceRemoved)
+    waveXlrSourceOm:activate()
+end
+
+nullSinkForWaveXlrSource = createNullSink();
 devicesOm:activate()
-linkOm:activate()
-linkOm:connect("object-added", onLinkCreated)
-waveXlrSourceOm:connect("object-added", onWaveXlrSourceAdded)
-waveXlrSourceOm:connect("object-removed", onWaveXlrSourceRemoved)
-waveXlrSourceOm:activate()
 
 log:notice("script initialized")


### PR DESCRIPTION
Fixes an issue in the script that causes it to fail to create a link between WaveXLR source and null sink occasionally.
```
wplua: [string "api.lua"]:57: Constraint: equals: expected constraint value
         stack traceback:
                 [C]: in function 'assert'
                 [string "api.lua"]:57: in global 'Constraint'
                 [string "wavexlrfix.lua"]:40: in global 'createLinkForWaveXlrSource'
                 [string "wavexlrfix.lua"]:156: in function <[string "wavexlrfix.lua"]:155>
```

This is due to a race condition between the creation of the null sink and the activation of the event listener for the WaveXLR source.